### PR TITLE
Periodic refresh

### DIFF
--- a/announcer.js
+++ b/announcer.js
@@ -13,7 +13,7 @@ var airtableCronJobs = [];
 // This is specifically offset from 5, 10, 15 minute intervals to ensure that 
 // a CRON job is not set to fire whe the CRON table is being refreshed
 
-const update_cron = '3 3 */1 * * *';
+const update_cron = '3 3 * * * *';
 
 new CronJob(update_cron, function () {
     // Explicitly stop all airtable CRON jobs 
@@ -33,6 +33,7 @@ new CronJob(update_cron, function () {
 
         records.forEach(function (record) {
 
+            var name = record.get('Name');
             var sec = record.get('Second');
             var min = record.get('Minute');
             var hor = record.get('Hour');
@@ -40,10 +41,15 @@ new CronJob(update_cron, function () {
             var mon = record.get('Month');
             var dow = record.get('Day of Week');
 
+            if (min > 1 && min < 5) {
+                min = 5;
+                console.log(`job ${name} was modified to run outside of the CRON table refresh window`);
+            }
+
             var airtable_cron = (sec + ' ' + min + ' ' + hor + ' ' + dom + ' ' + mon + ' ' + dow);
 
             airtableCronJobs.push(new CronJob(airtable_cron, function () {
-
+                console.log(`Running job ${name}`);
 
                 // See what channels are associated with this entry.
                 record.get('Channels').forEach(function (channel) {

--- a/announcer.js
+++ b/announcer.js
@@ -7,47 +7,66 @@ const base = new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY
 }).base(process.env.AIRTABLE_BASE);
 
-base('Slack Announcer').select({
-    view: "Announcer Filter"
-}).eachPage(function page(records, fetchNextPage) {
+const airtableCronJobs = [];
 
-    // This function (`page`) will get called for each page of records.
+// Flush and reload the CRON table at 3 minutes and 3 seconds past every hour
+// This is specifically offset from 5, 10, 15 minute intervals to ensure that 
+// a CRON job is not set to fire whe the CRON table is being refreshed
 
-    records.forEach(function (record) {
+const update_cron = '3 3 */1 * * *';
 
-        var sec = record.get('Second');
-        var min = record.get('Minute');
-        var hor = record.get('Hour');
-        var dom = record.get('Day of Month');
-        var mon = record.get('Month');
-        var dow = record.get('Day of Week');
+new CronJob(update_cron, function () {
+    // Explicitly stop all airtable CRON jobs 
+    airtableCronJobs.forEach(function (job) {
+        job.stop();
+    })
 
-        var airtable_cron = (sec + ' ' + min + ' ' + hor + ' ' + dom + ' ' + mon + ' ' + dow);
+    // Flush all CronJob instances
+    airtableCronJobs = [];
 
-        new CronJob(airtable_cron, function () {
+    // Refresh and start all CronJob instances from airtable
+    base('Slack Announcer').select({
+        view: "Announcer Filter"
+    }).eachPage(function page(records, fetchNextPage) {
+
+        // This function (`page`) will get called for each page of records.
+
+        records.forEach(function (record) {
+
+            var sec = record.get('Second');
+            var min = record.get('Minute');
+            var hor = record.get('Hour');
+            var dom = record.get('Day of Month');
+            var mon = record.get('Month');
+            var dow = record.get('Day of Week');
+
+            var airtable_cron = (sec + ' ' + min + ' ' + hor + ' ' + dom + ' ' + mon + ' ' + dow);
+
+            airtableCronJobs.push(new CronJob(airtable_cron, function () {
 
 
-            // See what channels are associated with this entry.
-            record.get('Channels').forEach(function (channel) {
+                // See what channels are associated with this entry.
+                record.get('Channels').forEach(function (channel) {
 
-                slack.send({
-                    text: record.get('Text'),
-                    channel: channel.toString(),
-                    username: record.get('Announcer Name')
-                });
+                    slack.send({
+                        text: record.get('Text'),
+                        channel: channel.toString(),
+                        username: record.get('Announcer Name')
+                    });
 
-            })
-        }, null, true, 'America/Los_Angeles');
+                })
+            }, null, true, 'America/Los_Angeles'));
 
+        });
+
+        // To fetch the next page of records, call `fetchNextPage`.
+        // If there are more records, `page` will get called again.
+        // If there are no more records, `done` will get called.
+        fetchNextPage();
+
+    }, function done(error) {
+        if (error) {
+            console.log(error);
+        }
     });
-
-    // To fetch the next page of records, call `fetchNextPage`.
-    // If there are more records, `page` will get called again.
-    // If there are no more records, `done` will get called.
-    fetchNextPage();
-
-}, function done(error) {
-    if (error) {
-        console.log(error);
-    }
 });

--- a/announcer.js
+++ b/announcer.js
@@ -7,7 +7,7 @@ const base = new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY
 }).base(process.env.AIRTABLE_BASE);
 
-const airtableCronJobs = [];
+var airtableCronJobs = [];
 
 // Flush and reload the CRON table at 3 minutes and 3 seconds past every hour
 // This is specifically offset from 5, 10, 15 minute intervals to ensure that 


### PR DESCRIPTION
I created created an array to store the CronJob Instances and wrapped most of the functionality defining the cron jobs in a meta-cron job that updates the virtual CRON table every hour at 3 minutes and 3 seconds past the hour by doing the following:

1. Explicitly stop all CronJob instances
2. Reinitialize the array storing all CronJob instances as an empty array
3. Pull all CronJobs from Airtable and push to array at CronJob instances set to auto-start

Closes #5 
